### PR TITLE
Polish CRAN version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Bayesian Estimation of reduced Reparametrized Unified Model
         (rRUM) with Gibbs Sampling
 Version: 2.0.0
 Authors@R: c(
-           person("Steven", "Culpepper", 
+           person("Steven Andrew", "Culpepper", 
                   email = "sculpepp@illinois.edu",
                   role = c("aut", "cph"),
                   comment = c(ORCID = "0000-0003-4226-6176")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,8 @@ Authors@R: c(
            person("Steven Andrew", "Culpepper", 
                   email = "sculpepp@illinois.edu",
                   role = c("aut", "cph"),
-                  comment = c(ORCID = "0000-0003-4226-6176")),
+                  comment = c(ORCID = "0000-0003-4226-6176")
+           ),
            person("Aaron", "Hudson", 
                   email = "awhudson@uw.edu", 
                   role = c("aut", "cph"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Description: Implementation of Gibbs sampling algorithm for Bayesian Estimation
     of reduced Reparametrized Unifed Model (rRUM), described by Culpepper and
     Hudson (2017) <doi: 10.1177/0146621617707511>.
 License: GPL (>= 2)
-Depends: R (>= 3.5.0), simcdm
+Depends: R (>= 3.4.0), simcdm (>= 0.1.0)
 Imports: Rcpp (>= 1.0.0)
 LinkingTo: Rcpp, RcppArmadillo, rgen, simcdm
 RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,9 +3,22 @@ Type: Package
 Title: Bayesian Estimation of reduced Reparametrized Unified Model
         (rRUM) with Gibbs Sampling
 Version: 2.0.0
-Authors@R: c(person("Steven", "Culpepper", email = "sculpepp@illinois.edu", role = c("aut", "cph")),
-           person("Aaron", "Hudson", email = "awhudson@uw.edu", role = c("aut", "cph")),
-           person("James", "Balamuta", email = "balamut2@illinois.edu", role = c("aut", "cre")))
+Authors@R: c(
+           person("Steven", "Culpepper", 
+                  email = "sculpepp@illinois.edu",
+                  role = c("aut", "cph"),
+                  comment = c(ORCID = "0000-0003-4226-6176")),
+           person("Aaron", "Hudson", 
+                  email = "awhudson@uw.edu", 
+                  role = c("aut", "cph"),
+                  comment = c(ORCID = "0000-0002-9731-2224")
+           ),
+           person("James Joseph", "Balamuta", 
+                  email = "balamut2@illinois.edu",
+                  role = c("aut", "cph", "cre"),
+                  comment = c(ORCID = "0000-0003-2826-8458")
+           )
+          )
 Description: Implementation of Gibbs sampling algorithm for Bayesian Estimation
     of reduced Reparametrized Unifed Model (rRUM), described by Culpepper and
     Hudson (2017) <doi: 10.1177/0146621617707511>.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,4 +36,3 @@ Suggests:
 VignetteBuilder: knitr
 SystemRequirements: C++11
 Encoding: UTF-8
-Remotes: tmsalab/simcdm

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Description: Implementation of Gibbs sampling algorithm for Bayesian Estimation
 License: GPL (>= 2)
 Depends: R (>= 3.4.0), simcdm (>= 0.1.0)
 Imports: Rcpp (>= 1.0.0)
-LinkingTo: Rcpp, RcppArmadillo, rgen, simcdm
+LinkingTo: Rcpp, RcppArmadillo (>= 0.9.200), rgen, simcdm
 RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
 Suggests: 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,6 @@
 export(rrum)
 importFrom(Rcpp,evalCpp)
 importFrom(simcdm,attribute_bijection)
-importFrom(simcdm,sim_attribute_classes)
+importFrom(simcdm,attribute_classes)
 importFrom(simcdm,sim_rrum_items)
 useDynLib(rrum, .registration=TRUE)

--- a/R/rrum-package.R
+++ b/R/rrum-package.R
@@ -1,6 +1,6 @@
 #' @useDynLib rrum, .registration=TRUE
 #' @importFrom Rcpp evalCpp
-#' @importFrom simcdm attribute_bijection sim_attribute_classes sim_rrum_items
+#' @importFrom simcdm attribute_bijection attribute_classes sim_rrum_items
 #' @details 
 #' Implemention of a bayesian estimation for the 
 #' reduced Reparametrized Unified Model (rRUM).

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -7,7 +7,7 @@ citEntry(entry = "Manual",
                                    as.person("James Joseph Balamuta")
                                   ),
          year         = 2019,
-         textVersion  = paste("Culpepper, S.A., Hudson, A., and Balamuta, J.J. (2019)",
+         textVersion  = paste("Culpepper, S. A., Hudson, A., and Balamuta, J. J. (2019)",
                               "rrum: Bayesian Estimation of reduced Reparametrized Unified Model (rRUM) with Gibbs Sampling.",
                               "URL https://cran.r-project.org/package=rrum.")
 )
@@ -23,7 +23,7 @@ citEntry(entry   = "Article",
          pages   = "99-115",
          year    = "2018",
          doi     = "10.1177/0146621617707511",
-         textVersion  = paste("Culpepper, S.A. and Hudson, A. (2018).",
+         textVersion  = paste("Culpepper, S. A. and Hudson, A. (2018).",
                               "An Improved Strategy for Bayesian Estimation of the Reduced Reparameterized Unified Model.",
                               "Applied Psychological Measurement, 42(2), 99–115.",
                               "URL https://doi.org/10.1177/0146621617707511.")

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,4 +1,4 @@
-citHeader("To cite 'rrum' in publications use:")
+citHeader("To cite the 'rrum' R package and method paper in publications use:")
 
 citEntry(entry = "Manual",
          title        = "{rrum: Bayesian Estimation of reduced Reparametrized Unified Model (rRUM) with Gibbs Sampling}",

--- a/man-roxygen/rrum-example.R
+++ b/man-roxygen/rrum-example.R
@@ -9,7 +9,7 @@
 #' K = 2    # Number of Attributes
 #' 
 #' # Matrix where rows represent attribute classes
-#' As = sim_attribute_classes(K) 
+#' As = attribute_classes(K) 
 #' 
 #' # Latent Class probabilities
 #' pis = c(.1, .2, .3, .4) 

--- a/man/rrum-package.Rd
+++ b/man/rrum-package.Rd
@@ -30,7 +30,7 @@ Carolina.
 
 Authors:
 \itemize{
-  \item Steven Culpepper \email{sculpepp@illinois.edu} (0000-0003-4226-6176) [copyright holder]
+  \item Steven Andrew Culpepper \email{sculpepp@illinois.edu} (0000-0003-4226-6176) [copyright holder]
   \item Aaron Hudson \email{awhudson@uw.edu} (0000-0002-9731-2224) [copyright holder]
 }
 

--- a/man/rrum-package.Rd
+++ b/man/rrum-package.Rd
@@ -26,12 +26,12 @@ annual International Meeting of the Psychometric Society, Asheville, North
 Carolina.
 }
 \author{
-\strong{Maintainer}: James Balamuta \email{balamut2@illinois.edu}
+\strong{Maintainer}: James Joseph Balamuta \email{balamut2@illinois.edu} (0000-0003-2826-8458) [copyright holder]
 
 Authors:
 \itemize{
-  \item Steven Culpepper \email{sculpepp@illinois.edu} [copyright holder]
-  \item Aaron Hudson \email{awhudson@uw.edu} [copyright holder]
+  \item Steven Culpepper \email{sculpepp@illinois.edu} (0000-0003-4226-6176) [copyright holder]
+  \item Aaron Hudson \email{awhudson@uw.edu} (0000-0002-9731-2224) [copyright holder]
 }
 
 }

--- a/man/rrum.Rd
+++ b/man/rrum.Rd
@@ -70,7 +70,7 @@ J = 6    # Number of Items
 K = 2    # Number of Attributes
 
 # Matrix where rows represent attribute classes
-As = sim_attribute_classes(K) 
+As = attribute_classes(K) 
 
 # Latent Class probabilities
 pis = c(.1, .2, .3, .4) 

--- a/man/rrum_helper.Rd
+++ b/man/rrum_helper.Rd
@@ -71,7 +71,7 @@ J = 6    # Number of Items
 K = 2    # Number of Attributes
 
 # Matrix where rows represent attribute classes
-As = sim_attribute_classes(K) 
+As = attribute_classes(K) 
 
 # Latent Class probabilities
 pis = c(.1, .2, .3, .4) 

--- a/src/rRUM_Gibbs.cpp
+++ b/src/rRUM_Gibbs.cpp
@@ -130,7 +130,7 @@ Rcpp::List rrum_main(const arma::mat &Y, const arma::mat &Q,
     unsigned int N = Y.n_rows;
     unsigned int J = Y.n_cols;
     unsigned int K = Q.n_cols;
-    unsigned int C = pow(2, K);
+    unsigned int C = static_cast<unsigned int>(pow(2.0, static_cast<double>(K)));
 
     arma::vec vv = simcdm::attribute_bijection(K);
 
@@ -234,7 +234,7 @@ Rcpp::List rrum_helper(const arma::mat &Y, const arma::mat &Q,
     }
     
     if (delta0.n_elem !=
-        static_cast<int>(pow(2.0, static_cast<double>(Q.n_cols)))) {
+        static_cast<unsigned int>(pow(2.0, static_cast<double>(Q.n_cols)))) {
         Rcpp::stop("`delta0` must be numeric of length 2 ^ ncol(Q)");
     }
 


### PR DESCRIPTION
In this PR, we:

- Improve the `DESCRIPTION` file by adding ORCiDs
- Fixed naming due to an update in `simcdm`.

TBD: When the `simcdm` 0.1.0 is updated, begin the push of `rrum` due to the use of `attribute_classes()` changing. 

**Note:** This means to remove the `Remotes` key in `DESCRIPTION`.